### PR TITLE
Use mesh-local network in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,3 +54,8 @@ services:
 
 volumes:
   db-data:
+
+networks:
+  default:
+    external: true
+    name: "mesh-local"


### PR DESCRIPTION
To have containers talk to each other cross project, user defined network will make our lives easier. Notably there will be inter-container DNS.

I am not particular on the name, but all the backend project should tie into the same one.

If a person runs compose without `mesh-local` defined then docker-compose will give a clear error message:

```
Network mesh-local declared as external, but could not be found. Please create the network manually using `docker network create mesh-local` and try again
```

Docker docs go as far as saying:
> User-defined bridge networks are superior to the default bridge network.

([Source](https://docs.docker.com/network/bridge/)). Which makes it seem like there isn't much benefit of using the default.