### PR TITLE
fix: 🐛 Revert to using snake case in extrinsics table

### DIFF
--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -2,7 +2,7 @@ import { mapAsset } from './entities/mapAsset';
 import { GenericExtrinsic } from '@polkadot/types/extrinsic';
 import { Vec } from '@polkadot/types/codec';
 import { AnyTuple, Codec } from '@polkadot/types/types';
-import { logFoundType, harvesterLikeParamsToObj } from './util';
+import { logFoundType, harvesterLikeParamsToObj, camelToSnakeCase } from './util';
 import { serializeLikeHarvester, serializeCallArgsLikeHarvester } from './serializeLikeHarvester';
 import { hexStripPrefix, u8aToHex } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
@@ -199,8 +199,8 @@ export async function handleCall(extrinsic: SubstrateExtrinsic): Promise<void> {
     extrinsicIdx,
     extrinsicLength: extrinsic.extrinsic.length,
     signed: extrinsic.extrinsic.isSigned ? 1 : 0,
-    moduleId,
-    callId,
+    moduleId: extrinsic.extrinsic.method.section.toLowerCase(),
+    callId: camelToSnakeCase(extrinsic.extrinsic.method.method),
     paramsTxt: JSON.stringify(params),
     success: extrinsic.success ? 1 : 0,
     signedbyAddress: signedbyAddress ? 1 : 0,


### PR DESCRIPTION
Tooling GQL expects snake case for call_id

Reverts the values to what they were [before](https://github.com/PolymathNetwork/polymesh-subquery/compare/v4.1.0-s1...v5.0.0#diff-cacfd1ec0155919c9a4ad17775cce37b7d92a736f89d84216e087d8f19405385L132)

Note the column names remain snake case in the DB despite the entity field being camel case.