### PR TITLE
feat: 🎸 Allow for dynamic lookup of NETWORK_CHAIN_ID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,8 @@ services:
       # NO_NATIVE_GRAPHQL_DATA: 'TRUE' # Setting this value only processes tooling specific handlers. Native subquery entities are ignored.
       # Polymesh-local
       NETWORK_ENDPOINT: ws://host.docker.internal:9944
-      NETWORK_CHAIN_ID: '0xda7f2072787bfd0b09f7e12fca619afb6041b3d620f39f3a508814869100bf01'
+      # Setting NETWORK_HTTP_ENDPOINT will allow dynamic lookup of NETWORK_CHAIN_ID
+      NETWORK_HTTP_ENDPOINT: 'http://host.docker.internal:9933'
       # Staging
       # NETWORK_ENDPOINT: wss://staging-rpc.polymesh.live
       # NETWORK_CHAIN_ID: '0x3c3183f6d701500766ff7d147b79c4f10014a095eaaa98e960dcef6b3ead50ee'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,15 @@ then
 else
   export EVENT_HANDLER='handleEvent'
 fi
+# If NETWORK_CHAIN_ID is not set and we have an http endpoint to use, then curl the chain to fetch it (might need to retry)
+if [[ -n $NETWORK_HTTP_ENDPOINT ]] && [[ -z $NETWORK_CHAIN_ID ]]
+then
+  export NETWORK_CHAIN_ID=$(curl --silent -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getBlockHash", "params":[0]}' $NETWORK_HTTP_ENDPOINT |
+  grep -o '"result":"[^"]*' |
+  grep -o '[^"]*$'
+)
+  echo "NETWORK_CHAIN_ID was set to ${NETWORK_CHAIN_ID} based on calling: $CHAIN_HTTP_ENDPOINT. Production chains should explictly set NETWORK_CHAIN_ID instead"
+fi
 
 envsubst <project.template.yaml> project.yaml
 


### PR DESCRIPTION
By setting the HTTP endpoint for the chain we can dynamically get the
chain id needed for SubQuery

### Description

By setting `NETWORK_HTTP_ENDPOINT` SubQuery can dynamically figure out the chain id. Without this chain it will be cumbersome to use with polymesh_local, or any other ephemeral dev chain.

Its possible to get this info over ws, but from a script its a bit harder. Also with this way we won't infer it by mistake in production environments.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
