### PR TITLE
fix: 🐛 serialize ticker for type `PolymeshPrimitivesTicker`

### DIFF
--- a/src/mappings/serializeLikeHarvester.ts
+++ b/src/mappings/serializeLikeHarvester.ts
@@ -74,7 +74,7 @@ export const serializeLikeHarvester = (
     }
   } else if (rawType === 'Text') {
     return removeNullChars(item.toString());
-  } else if (type === 'Ticker') {
+  } else if (type === 'Ticker' || type === 'PolymeshPrimitivesTicker') {
     return serializeTicker(item);
   } else if (rawType === 'Call') {
     const e = item as unknown as GenericCall;


### PR DESCRIPTION
### Description

Type value for `Ticker` was changed to `PolymeshPrimitivesTicker` with 5.0.0 upgrade and subquery missed serialising objects for this type. Added the check for the new type as well along with the old type.

### JIRA Link

DA-371

### Checklist

- [ ] Updated the Readme.md (if required) ?
